### PR TITLE
Fixed interactivity error when there are more than touch at the same time

### DIFF
--- a/control/lib/interaction.js
+++ b/control/lib/interaction.js
@@ -156,9 +156,13 @@ wax.interaction = function() {
             // but also wax.u.eventoffset will have failed, since this touch
             // event doesn't have coordinates
             interaction.click(e, _d);
-        } else if (evt.type === "MSPointerMove" || evt.type === "MSPointerUp") {
+        } else if (pos) {
+          // If pos is not defined means wax can't calculate event position,
+          // So next cases aren't possible.
+
+          if (evt.type === "MSPointerMove" || evt.type === "MSPointerUp") {
             interaction.click(evt, pos);
-        } else if (Math.round(pos.y / tol) === Math.round(_d.y / tol) &&
+          } else if (Math.round(pos.y / tol) === Math.round(_d.y / tol) &&
             Math.round(pos.x / tol) === Math.round(_d.x / tol)) {
             // Contain the event data in a closure.
             // Ignore double-clicks by ignoring clicks within 300ms of
@@ -171,7 +175,10 @@ wax.interaction = function() {
             } else {
               killTimeout();
             }
+          }
+
         }
+
         return onUp;
     }
 


### PR DESCRIPTION
For example, a user zooming using two fingers raised an error trying to get the event offset. Not possible because it is not an only touch event.
