### PR TITLE
Add upper limit to y as a 2 power of zoom

### DIFF
--- a/connectors/g/connector.js
+++ b/connectors/g/connector.js
@@ -72,7 +72,7 @@ wax.g.connector.prototype.getTileUrl = function(coord, z) {
 
     x = (x < 0) ? (coord.x % mod) + mod : x;
 
-    if (y < 0) return this.options.blankImage;
+    if (y < 0 || y > (mod - 1)) return this.options.blankImage;
 
     return this.options.tiles
         [parseInt(x + y, 10) %


### PR DESCRIPTION
Fix for https://github.com/CartoDB/cartodb.js/issues/1540

Wax generate an Image node on the fly based on the coords and zoom level, It controls the Y bottom limmit but not the upper limit.

As every increase is divided by 4 with each level of zoom, it is an exponential increase of tiles, so the Y upper limit has to be 2 ^ zoom, and as we start to count at 0, not 1, it has to be minus one.

If this limit is reached we have to return a default transparent image node in base64.