### PR TITLE
Timeout limits

### DIFF
--- a/control/lib/gridmanager.js
+++ b/control/lib/gridmanager.js
@@ -109,6 +109,7 @@ wax.gm = function() {
 
         wax.request.get(gurl, function(err, t) {
             if (err) return callback(err, null);
+            if (t.errors_with_context) return callback(t.errors_with_context, null);
             callback(null, wax.gi(t, {
                 formatter: formatter,
                 resolution: resolution

--- a/control/lib/interaction.js
+++ b/control/lib/interaction.js
@@ -16,8 +16,8 @@ wax.interaction = function() {
         parent,
         map,
         tileGrid,
-        // google maps sends touchmove and click at the same time 
-        // most of the time when an user taps the screen, see onUp 
+        // google maps sends touchmove and click at the same time
+        // most of the time when an user taps the screen, see onUp
         // for more information
         _discardTouchMove = false;
 
@@ -84,7 +84,7 @@ wax.interaction = function() {
         var _e = (e.type !== "MSPointerMove" && e.type !== "pointermove" ? e : e.originalEvent);
         var pos = wax.u.eventoffset(_e);
 
-        interaction.screen_feature(pos, function(feature) {
+        interaction.screen_feature(pos, function(error, feature) {
             if (feature) {
                 bean.fire(interaction, 'on', {
                     parent: parent(),
@@ -93,7 +93,9 @@ wax.interaction = function() {
                     e: e
                 });
             } else {
-                bean.fire(interaction, 'off');
+                bean.fire(interaction, 'off', error && {
+                    errors: error
+                });
             }
         });
     }
@@ -107,7 +109,7 @@ wax.interaction = function() {
         // Store this event so that we can compare it to the
         // up event
         _downLock = true;
-        var _e = (e.type !== "MSPointerDown" && e.type !== "pointerdown" ? e : e.originalEvent); 
+        var _e = (e.type !== "MSPointerDown" && e.type !== "pointerdown" ? e : e.originalEvent);
         _d = wax.u.eventoffset(_e);
         if (e.type === 'mousedown') {
             bean.add(document.body, 'click', onUp);
@@ -120,7 +122,7 @@ wax.interaction = function() {
             //GMaps fix: Because it's triggering always mousedown and click, we've to remove it
             bean.remove(document.body, 'click', onUp); //GMaps fix
 
-            //When we finish dragging, then the click will be 
+            //When we finish dragging, then the click will be
             bean.add(document.body, 'click', onUp);
             bean.add(document.body, 'touchEnd', dragEnd);
         } else if (e.originalEvent.type === "MSPointerDown" && e.originalEvent.touches && e.originalEvent.touches.length === 1) {
@@ -219,7 +221,7 @@ wax.interaction = function() {
 
     // Handle a click event. Takes a second
     interaction.click = function(e, pos) {
-        interaction.screen_feature(pos, function(feature) {
+        interaction.screen_feature(pos, function(err, feature) {
             if (feature) bean.fire(interaction, 'on', {
                 parent: parent(),
                 data: feature,
@@ -231,9 +233,10 @@ wax.interaction = function() {
 
     interaction.screen_feature = function(pos, callback) {
         var tile = getTile(pos);
-        if (!tile) callback(null);
+        if (!tile) callback(null, null);
         gm.getGrid(tile.src, function(err, g) {
-            if (err || !g) return callback(null);
+            if (err) return callback(err, null);
+            if (!g) return callback(null, null);
             var feature = g.tileFeature(pos.x, pos.y, tile);
             callback(feature);
         });

--- a/control/lib/interaction.js
+++ b/control/lib/interaction.js
@@ -238,7 +238,7 @@ wax.interaction = function() {
             if (err) return callback(err, null);
             if (!g) return callback(null, null);
             var feature = g.tileFeature(pos.x, pos.y, tile);
-            callback(feature);
+            callback(null, feature);
         });
     };
 


### PR DESCRIPTION
This PR is related to https://github.com/CartoDB/cartodb.js/issues/1717. It fixes #16.

Because we are handling the grid.json as jsonp, it's not possible to send a `429` error, so we need to catch the error wrapped from the tiles.